### PR TITLE
Only store data for UTC "timezone"

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -53,17 +53,6 @@ correctly generated. Then migrate the database to the updated version using
 ### Space requirements
 
 For each validator, its balance is stored in the database
-approximately every 30 minutes (for every major timezone as defined by pytz).
+once daily - every 24 hours.
 On-demand balance retrieval from the beacon node would be time-consuming,
 and for a year's worth of data would take quite a long time.
-
-This takes up quite a lot of space. At the time of writing (March 31st 2022),
-it takes up 204 GB, so about 13 GB / month. The more validators there are,
-the quicker the growth.
-
-These are some ideas I've had on reducing the database size:
-
-- only store the balances for one timezone, e.g. UTC
-- make the rewards calculation an async operation - e.g. the user requests the data,
-  and can find them an hour later on the website based on the previous request
-  - this way a small amount of data could be stored for a limited time period (1 day or week)

--- a/src/api/api_v1/endpoints/rewards.py
+++ b/src/api/api_v1/endpoints/rewards.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 TimezoneEnum = Enum(
     "TimezoneEnum",
-    {timezone.replace("/", ""): timezone for timezone in pytz.common_timezones},
+    {"UTC": "UTC",}
 )
 
 REWARDS_REQUEST_COUNT = Counter(
@@ -66,7 +66,7 @@ async def rewards(
     timezone: TimezoneEnum = Query(
         ...,
         description="The timezone for which to calculate rewards.",
-        example=TimezoneEnum.EuropeAmsterdam,
+        example=TimezoneEnum.UTC,
     ),
     currency: str = Query(
         ...,

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -9,7 +9,6 @@ from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
 from starlette_exporter import PrometheusMiddleware, handle_metrics
 from aioredis import Redis
-from pytz import common_timezones
 
 from providers.coin_gecko import CoinGecko
 from shared.setup_logging import setup_logging
@@ -34,7 +33,6 @@ async def read_root(
         "root.html",
         {
             "request": request,
-            "common_timezones": common_timezones,
             "currencies": currencies,
         },
     )

--- a/src/frontend/static/app.js
+++ b/src/frontend/static/app.js
@@ -24,17 +24,6 @@ function addInputElement(e) {
     newInputGroup.children[0].focus()
 }
 
-function autoSelectTimezone() {
-    userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-    selectElement = document.getElementById("selectTimezone");
-    for (i = 0; i < selectElement.length; ++i){
-        if (selectElement.options[i].value == userTimeZone){
-            selectElement.value = Intl.DateTimeFormat().resolvedOptions().timeZone
-        }
-    }
-}
-
 function initDatePickers() {
 
 }
@@ -90,7 +79,6 @@ function selectDateRangeByYear() {
     }
 }
 
-window.addEventListener("load", autoSelectTimezone);
 window.addEventListener("load", initDatePickers);
 
 window.addEventListener("load", () => {
@@ -208,7 +196,7 @@ function getRewardsForValidatorIndexes(validatorIndexes) {
     params.append("start_date", document.getElementById("datePickerStart").value)
     params.append("end_date", document.getElementById("datePickerEnd").value)
 
-    params.append("timezone", document.getElementById("selectTimezone").value)
+    params.append("timezone", "UTC")
 
     params.append("currency", document.getElementById("selectCurrency").value)
 

--- a/src/frontend/templates/root.html
+++ b/src/frontend/templates/root.html
@@ -94,20 +94,6 @@
                 </div>
             </div>
             <div class="row p-3">
-                <h2>What timezone are you in?</h2>
-                <p>
-                    The timezone is taken into account to accurately count the rewards
-                    for each day up until midnight in the specified timezone.
-                </p>
-                <div class="input-group mb-1 p-2">
-                    <select class="form-select" id="selectTimezone">
-                    {% for tz in common_timezones %}
-                        <option value="{{ tz }}">{{ tz }}</option>
-                    {% endfor %}
-                    </select>
-                </div>
-            </div>
-            <div class="row p-3">
                 <h2>Which currency would you like to calculate the rewards in?</h2>
                 <p>
                     The total amount of rewards will be returned in ETH

--- a/src/indexer/balances.py
+++ b/src/indexer/balances.py
@@ -18,6 +18,9 @@ logger = logging.getLogger(__name__)
 engine = create_engine(get_db_uri(), executemany_mode="batch")
 
 START_DATE = "2020-01-01"
+TIMEZONES_TO_INDEX = (
+    pytz.utc,
+)
 
 ALREADY_INDEXED_SLOTS = set()
 
@@ -49,11 +52,10 @@ async def index_balances():
 
     beacon_node = BeaconNode()
 
-    logger.info(f"Indexing balances for {len(pytz.common_timezones)} timezones.")
+    logger.info(f"Indexing balances for {len(TIMEZONES_TO_INDEX)} timezones.")
     slots_needed = set()
     logger.debug(f"Calculating the needed slot numbers...")
-    for timezone in pytz.common_timezones:
-        timezone = pytz.timezone(timezone)
+    for timezone in TIMEZONES_TO_INDEX:
 
         start_dt = datetime.datetime.combine(start_date, datetime.time.min)
         end_dt = datetime.datetime.combine(end_date, datetime.time.min)


### PR DESCRIPTION
Indexing the balance data for all timezones has started to become really unsustainable for me to maintain, taking up 200GB of disk space.

From now on, balances will only be indexed and available once every 24 hours at 12am UTC.